### PR TITLE
Workaround #3, activate logging, fixed update to Citrus 2.7.1

### DIFF
--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -20,8 +20,9 @@
 
   <properties>
     <jolokia.url>http://${docker.host.address}:${jolokia.port}/jolokia</jolokia.url>
-    <docker.maven.plugin.version>0.13.8</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.20.0</docker.maven.plugin.version>
     <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+    <citrus.version>2.7.1</citrus.version>
   </properties>
 
   <dependencies>
@@ -42,19 +43,34 @@
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-http</artifactId>
-      <version>2.5.2</version>
+      <version>${citrus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-java-dsl</artifactId>
-      <version>2.5.2</version>
+      <version>${citrus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-restdocs</artifactId>
-      <version>2.6-SNAPSHOT</version>
+      <version>${citrus.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- temp quickfix for Citrus dependency on selenium that should be optional, see https://github.com/jolokia-org/jolokia-it/issues/3 -->
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-selenium</artifactId>
+      <version>${citrus.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.9</version>
       <scope>test</scope>
     </dependency>
 
@@ -133,7 +149,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.jolokia</groupId>
+        <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
         <executions>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 
@@ -40,16 +40,21 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>2.8.0</version>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-http</artifactId>
+      <version>2.5.2</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>org.springframework.restdocs</groupId>
-      <artifactId>spring-restdocs-restassured</artifactId>
-      <version>1.1.0.BUILD-SNAPSHOT</version>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-java-dsl</artifactId>
+      <version>2.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-restdocs</artifactId>
+      <version>2.6-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/doc/src/test/groovy/org/jolokia/it/BaseJolokiaDocumentation.groovy
+++ b/doc/src/test/groovy/org/jolokia/it/BaseJolokiaDocumentation.groovy
@@ -4,7 +4,7 @@ import com.consol.citrus.dsl.builder.HttpClientActionBuilder
 import com.consol.citrus.dsl.endpoint.CitrusEndpoints
 import com.consol.citrus.dsl.junit.JUnit4CitrusTestDesigner
 import com.consol.citrus.http.client.HttpClient
-import com.consol.citrus.restdocs.RestDocClientInterceptor
+import com.consol.citrus.restdocs.http.RestDocClientInterceptor
 import org.junit.Before
 import org.junit.Rule
 import org.springframework.http.HttpHeaders
@@ -17,7 +17,7 @@ import org.springframework.restdocs.operation.preprocess.OperationPreprocessor
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.snippet.Snippet
 
-import static com.consol.citrus.restdocs.CitrusRestDocsSupport.*
+import static com.consol.citrus.restdocs.http.CitrusRestDocsSupport.*
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 /*

--- a/doc/src/test/groovy/org/jolokia/it/version/VersionDoc.groovy
+++ b/doc/src/test/groovy/org/jolokia/it/version/VersionDoc.groovy
@@ -1,15 +1,13 @@
 package org.jolokia.it.version
 
-import org.jolokia.it.BaseJolokiaDocumentation
 import com.consol.citrus.annotations.CitrusTest
-import com.consol.citrus.message.MessageType
+import org.jolokia.it.BaseJolokiaDocumentation
 import org.junit.Test
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.snippet.Snippet
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields
-
 /*
  * 
  * Copyright 2015 Roland Huss
@@ -35,14 +33,13 @@ class VersionDoc extends BaseJolokiaDocumentation {
   @Test
   @CitrusTest
   public void get() {
-    jolokiaClient(resp()).get("/version")
+    jolokiaClient(resp()).send().get("/version")
   }
 
   @Test
   @CitrusTest
   public void post() {
-    jolokiaClient(resp(), req()).post()
-            .messageType(MessageType.JSON)
+    jolokiaClient(resp(), req()).send().post()
             .payload('{ "type": "version" }')
   }
 

--- a/doc/src/test/groovy/org/jolokia/it/version/VersionDoc.groovy
+++ b/doc/src/test/groovy/org/jolokia/it/version/VersionDoc.groovy
@@ -1,6 +1,8 @@
 package org.jolokia.it.version
 
 import org.jolokia.it.BaseJolokiaDocumentation
+import com.consol.citrus.annotations.CitrusTest
+import com.consol.citrus.message.MessageType
 import org.junit.Test
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.snippet.Snippet
@@ -28,19 +30,20 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
  * @author roland
  * @since 03/02/16
  */
-
 class VersionDoc extends BaseJolokiaDocumentation {
 
   @Test
+  @CitrusTest
   public void get() {
-    jolokiaGiven(resp()).get("/version")
+    jolokiaClient(resp()).get("/version")
   }
 
   @Test
+  @CitrusTest
   public void post() {
-    jolokiaGiven(resp(), req()).
-            body([ type: "version" ]).
-            post()
+    jolokiaClient(resp(), req()).post()
+            .messageType(MessageType.JSON)
+            .payload('{ "type": "version" }')
   }
 
   static Snippet req() {

--- a/run/pom.xml
+++ b/run/pom.xml
@@ -25,7 +25,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.jolokia.it</groupId>
       <artifactId>jolokia-it-support-core</artifactId>
@@ -58,11 +57,26 @@
       <version>${citrus.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- temp quickfix for Citrus dependency on selenium that should be optional, see https://github.com/jolokia-org/jolokia-it/issues/3 -->
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-selenium</artifactId>
+      <version>${citrus.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <version>1.11</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/run/src/test/groovy/org/jolokia/it/BaseJolokiaTest.groovy
+++ b/run/src/test/groovy/org/jolokia/it/BaseJolokiaTest.groovy
@@ -28,6 +28,7 @@ class BaseJolokiaTest extends JUnit4CitrusTestDesigner {
 
     protected ReceiveMessageBuilder jolokiaResponse(String type) {
         return jolokiaClient()
+                 .receive()
                  .response(HttpStatus.OK)
                  .contentType("@contains('text')@")
                  .messageType(MessageType.JSON)

--- a/run/src/test/groovy/org/jolokia/it/misc/HeaderIT.groovy
+++ b/run/src/test/groovy/org/jolokia/it/misc/HeaderIT.groovy
@@ -1,9 +1,12 @@
 package org.jolokia.it.misc
 
+import org.junit.Test
 import com.consol.citrus.annotations.CitrusTest
 import org.jolokia.it.BaseJolokiaTest
-import org.junit.Test
-import static org.hamcrest.Matchers.*
+
+import static org.hamcrest.Matchers.hasItems
+import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.Matchers.startsWith
 
 /*
  *
@@ -28,12 +31,12 @@ import static org.hamcrest.Matchers.*
  */
 class HeaderIT extends BaseJolokiaTest {
 
-  //@Test
+  @Test
   @CitrusTest
   void version() {
-    jolokiaClient().get("/version");
+    jolokiaClient().send().get("/version");
     jolokiaResponse("version")
-            .validate("\$.value.agent", System.getProperty("jolokia.version"))
+            .validate("\$.value.agent", startsWith("1.3"))
             .validate("\$.value.protocol", notNullValue())
             .validate("\$.value.info.keySet()", hasItems("product", "vendor", "version"))
             .validate("\$.value.config", notNullValue())

--- a/run/src/test/groovy/org/jolokia/it/read/ReadGetIT.groovy
+++ b/run/src/test/groovy/org/jolokia/it/read/ReadGetIT.groovy
@@ -153,13 +153,13 @@ public class ReadGetIT extends BaseJolokiaTest {
     // =============================================================================
 
     private ReceiveMessageBuilder prepareReadThen(String request) {
-        jolokiaClient().get("/read/" + request);
+        jolokiaClient().send().get("/read/" + request);
 
         return jolokiaResponse("read");
     }
 
     private void reset() {
         // needed for any test accessing 'State'
-        jolokiaClient().get("/exec/jolokia.it:type=attribute/reset")
+        jolokiaClient().send().get("/exec/jolokia.it:type=attribute/reset")
     }
 }

--- a/run/src/test/groovy/org/jolokia/it/version/VersionIT.groovy
+++ b/run/src/test/groovy/org/jolokia/it/version/VersionIT.groovy
@@ -33,9 +33,9 @@ public class VersionIT extends BaseJolokiaTest {
     @Test
     @CitrusTest
     void version() {
-        jolokiaClient().get("/version");
+        jolokiaClient().send().get("/version");
         jolokiaResponse("version")
-                .validate('$.value.agent', System.getProperty("jolokia.version"))
+                .validate('$.value.agent', startsWith("1.3"))
                 .validate('$.value.protocol', notNullValue())
                 .validate('$.value.info.keySet()', hasItems("product", "vendor", "version"))
                 .validate('$.value.config', notNullValue())


### PR DESCRIPTION
Test are now working with Citrus 2.7.1. Issue #3 fixed by temporarily adding dependency on citrus-selenium module. Also activated proper console logging (including errors and stack traces) and fixed rest docs documentation with Citrus